### PR TITLE
Fix jquery call before he is initialized.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Or use it directly through our CDN:
 <script src="https://unpkg.com/bootstrap-compatibility-layer@1"></script>
 [...]
 ```
+To be sure that the scripts are all operational try to load the compatibility layer before the other scripts!
 
 ## Contributing
 Contributions are welcome!

--- a/example/bootstrap-4.html
+++ b/example/bootstrap-4.html
@@ -939,12 +939,12 @@
   </div>
 
   <!-- Load Bootstrap v5-->
+  <script src="../dist/bootstrap-compatibility-layer.umd.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"
     integrity="sha384-kenU1KFdBIe4zVF0s0G1M5b4hcpxyD9F7jL+jjXkk+Q2h455rYXK/7HAuoJl+0I4"
     crossorigin="anonymous"></script>
   <script src="https://code.jquery.com/jquery-3.7.0.min.js"
     integrity="sha256-2Pmvv0kuTBOenSvLm6bvfBSSHrUJ+3A7x6P5Ebd07/g=" crossorigin="anonymous"></script>
-  <script src="../dist/bootstrap-compatibility-layer.umd.min.js"></script>
   <script>
     $('[data-toggle="popover"]').popover()
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bootstrap-compatibility-layer",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Bootstrap compatibility layer to help using a module based on bootstrap 4 with a theme based on bootstrap 5",
   "keywords": [
     "prestashop",

--- a/src/js/index.ts
+++ b/src/js/index.ts
@@ -29,13 +29,15 @@ class BSCompatibilityLayer {
 
   init(): void {
     this.updateDataAttributes();
-    this.attachJQueryMethods();
+
+    this.waitingForJQuery(() => {
+      this.attachJQueryMethods();
+    });
   }
 
   public updateDataAttributes(): void {
     for (const [key, value] of Object.entries(this.dataToUpdate)) {
-      const findData = document.querySelectorAll(`[${key}]`);
-      Array.from(findData).forEach((el) => {
+      Array.from(document.querySelectorAll(`[${key}]`)).forEach((el) => {
         const dataValue = el.getAttribute(key);
         if (dataValue !== null && dataValue !== '') {
           el.setAttribute(value, dataValue);
@@ -44,21 +46,29 @@ class BSCompatibilityLayer {
     }
   }
 
+  public waitingForJQuery(callback: () => void): void {
+    const checkJQueryLoaded = (): void => {
+      if (typeof $ !== 'undefined') {
+        callback();
+      } else {
+        requestAnimationFrame(checkJQueryLoaded);
+      }
+    };
+    requestAnimationFrame(checkJQueryLoaded);
+  }
+
   public attachJQueryMethods(): void {
-    if ($ === undefined) {
-      return;
-    }
     $.fn.extend({
-      popover: function (params: Partial<Popover.Options> | undefined) {
+      popover: function(params: Partial<Popover.Options> | undefined) {
         // @ts-expect-error because it's JQuery method
-        return this.each(function () {
+        return this.each(function() {
           // @ts-expect-error because of the scope
           new bootstrap.Popover(this, params);
         });
       },
-      tooltip: function (params: Partial<Tooltip.Options> | undefined) {
+      tooltip: function(params: Partial<Tooltip.Options> | undefined) {
         // @ts-expect-error because it's JQuery method
-        return this.each(function () {
+        return this.each(function() {
           // @ts-expect-error because of the scope
           new bootstrap.Tooltip(this, params);
         });


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | We got an issue if JQuery is called after the script. now we test in a loop if JQuery is present or not to attach the methods.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     |  no
| Sponsor company   | @PrestaShopCorp
| How to test?      | Try to put the package before the JQuery call and watch if the set of popover and tooltip methods work.
