### PR TITLE
Remove JQuery methods because also implemented into Bootstrap 5

### DIFF
--- a/example/bootstrap-4-no-bcl.html
+++ b/example/bootstrap-4-no-bcl.html
@@ -155,7 +155,6 @@
   </style>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet"
     integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
-  <link href="../dist/bootstrap-compatibility-layer.min.css" rel="stylesheet">
 </head>
 
 <body>
@@ -164,8 +163,8 @@
       <div class="col-12 col-md-4 col-lg-3">
         <div id="toc-wrapper">
           <div class="bs-switch">
-            <a class="bs-switch__link" href="../example/bootstrap-4-no-bcl.html">
-              <span class="bs-switch__switcher"></span>
+            <a class="bs-switch__link" href="../example/bootstrap-4.html">
+              <span class="bs-switch__switcher bs-switch__switcher--off"></span>
               <span class="bs-switch__label">Compatibility Layer</span>
             </a>
           </div>
@@ -992,7 +991,6 @@
   </div>
 
   <!-- Load Bootstrap v5-->
- <script src="../dist/bootstrap-compatibility-layer.umd.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"
     integrity="sha384-kenU1KFdBIe4zVF0s0G1M5b4hcpxyD9F7jL+jjXkk+Q2h455rYXK/7HAuoJl+0I4"
     crossorigin="anonymous"></script>

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,2 +1,0 @@
-declare let bootstrap: import('bootstrap');
-declare let $: import('jquery');

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -2,8 +2,6 @@
  * For a detailed explanation regarding each configuration property and type check, visit:
  * https://jestjs.io/docs/configuration
  */
-import $ from 'jquery';
-import bootstrap from 'bootstrap';
 
 export default {
   preset: 'ts-jest',
@@ -14,7 +12,4 @@ export default {
   transform: {
     '^.+\\.scss$': 'jest-scss-transform'
   },
-  globals: {
-    $: undefined
-  }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bootstrap-compatibility-layer",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bootstrap-compatibility-layer",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "http-server": "^14.1.1"
@@ -14,9 +14,7 @@
       "devDependencies": {
         "@prestashopcorp/eslint-config-ts": "^0.0.10",
         "@prestashopcorp/stylelint-config": "^0.0.3",
-        "@types/bootstrap": "^5.2.6",
         "@types/jest": "^29.5.2",
-        "@types/jquery": "^3.5.16",
         "@types/jsdom": "^21.1.1",
         "@types/node": "^20.3.1",
         "@typescript-eslint/eslint-plugin": "^5.60.0",
@@ -1187,15 +1185,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@popperjs/core": {
-      "version": "2.11.8",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
-      }
-    },
     "node_modules/@prestashopcorp/eslint-config": {
       "version": "0.0.9",
       "dev": true,
@@ -1345,14 +1334,6 @@
         "@babel/types": "^7.20.7"
       }
     },
-    "node_modules/@types/bootstrap": {
-      "version": "5.2.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@popperjs/core": "^2.9.2"
-      }
-    },
     "node_modules/@types/estree": {
       "version": "1.0.1",
       "dev": true,
@@ -1394,14 +1375,6 @@
       "dependencies": {
         "expect": "^29.0.0",
         "pretty-format": "^29.0.0"
-      }
-    },
-    "node_modules/@types/jquery": {
-      "version": "3.5.16",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/sizzle": "*"
       }
     },
     "node_modules/@types/jsdom": {
@@ -1451,11 +1424,6 @@
     },
     "node_modules/@types/semver": {
       "version": "7.5.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/sizzle": {
-      "version": "2.3.3",
       "dev": true,
       "license": "MIT"
     },
@@ -8578,10 +8546,6 @@
         "fastq": "^1.6.0"
       }
     },
-    "@popperjs/core": {
-      "version": "2.11.8",
-      "dev": true
-    },
     "@prestashopcorp/eslint-config": {
       "version": "0.0.9",
       "dev": true
@@ -8683,13 +8647,6 @@
         "@babel/types": "^7.20.7"
       }
     },
-    "@types/bootstrap": {
-      "version": "5.2.6",
-      "dev": true,
-      "requires": {
-        "@popperjs/core": "^2.9.2"
-      }
-    },
     "@types/estree": {
       "version": "1.0.1",
       "dev": true
@@ -8725,13 +8682,6 @@
       "requires": {
         "expect": "^29.0.0",
         "pretty-format": "^29.0.0"
-      }
-    },
-    "@types/jquery": {
-      "version": "3.5.16",
-      "dev": true,
-      "requires": {
-        "@types/sizzle": "*"
       }
     },
     "@types/jsdom": {
@@ -8773,10 +8723,6 @@
     },
     "@types/semver": {
       "version": "7.5.0",
-      "dev": true
-    },
-    "@types/sizzle": {
-      "version": "2.3.3",
       "dev": true
     },
     "@types/stack-utils": {

--- a/package.json
+++ b/package.json
@@ -33,14 +33,11 @@
     "test": "jest --config=jest.config.ts",
     "test:watch": "jest --watch --config=jest.config.ts",
     "example": "npx http-server -o example/bootstrap-4.html -p 0"
-
   },
   "devDependencies": {
     "@prestashopcorp/eslint-config-ts": "^0.0.10",
     "@prestashopcorp/stylelint-config": "^0.0.3",
-    "@types/bootstrap": "^5.2.6",
     "@types/jest": "^29.5.2",
-    "@types/jquery": "^3.5.16",
     "@types/jsdom": "^21.1.1",
     "@types/node": "^20.3.1",
     "@typescript-eslint/eslint-plugin": "^5.60.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bootstrap-compatibility-layer",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Bootstrap compatibility layer to help using a module based on bootstrap 4 with a theme based on bootstrap 5",
   "keywords": [
     "prestashop",

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -22,20 +22,12 @@ export default {
       name: 'bootstrap-compatibility-layer',
       file: pkg.browser,
       format: 'umd',
-      exports: 'named',
-      globals: {
-        bootstrap: 'bootstrap',
-        $: '$'
-      }
+      exports: 'named'
     },
     {
       file: pkg.module,
       format: 'es',
-      exports: 'named',
-      globals: {
-        bootstrap: 'bootstrap',
-        $: '$'
-      }
+      exports: 'named'
     }
   ]
 };

--- a/src/js/index.ts
+++ b/src/js/index.ts
@@ -1,5 +1,4 @@
 import '../styles/index.scss';
-import { type Popover, type Tooltip } from 'bootstrap';
 
 // The BSCompatibilityLayer class is responsible for updating the data attributes of HTML elements to be compatible with Bootstrap 5. It also initializes the popover and tooltip components of Bootstrap 5.
 export class BSCompatibilityLayer {
@@ -30,15 +29,13 @@ export class BSCompatibilityLayer {
   init(): void {
     this.updateAllDataAttributes();
     this.attachObserver();
-
-    this.waitingForJQuery(() => {
-      this.attachJQueryMethods();
-    });
   }
 
   // Updates all data attributes in the HTML document that match the keys in the `dataToUpdate` map.
   public updateAllDataAttributes(): void {
-    const elements = document.querySelectorAll(`[${Array.from(this.dataToUpdate.keys()).join('], [')}]`);
+    const elements = document.querySelectorAll(
+      `[${Array.from(this.dataToUpdate.keys()).join('], [')}]`
+    );
     elements.forEach((el) => {
       Array.from(this.dataToUpdate.keys()).forEach((key) => {
         if (el.hasAttribute(key)) {
@@ -83,45 +80,17 @@ export class BSCompatibilityLayer {
             }
           }
         });
-      } else if (mutation.type === 'attributes' && mutation.attributeName !== null && this.dataToUpdate.has(mutation.attributeName)) {
+      } else if (
+        mutation.type === 'attributes' &&
+        mutation.attributeName !== null &&
+        this.dataToUpdate.has(mutation.attributeName)
+      ) {
         const targetElement = mutation.target;
         if (targetElement instanceof Element) {
           this.updateDataAttributes(targetElement, mutation.attributeName);
         }
       }
     }
-  }
-
-  // Waits for jQuery to be loaded before calling a callback function.
-  public waitingForJQuery(callback: () => void): void {
-    const checkJQueryLoaded = (): void => {
-      if (typeof $ !== 'undefined') {
-        callback();
-      } else {
-        requestAnimationFrame(checkJQueryLoaded);
-      }
-    };
-    requestAnimationFrame(checkJQueryLoaded);
-  }
-
-  // Extends the jQuery object with BS methods.
-  public attachJQueryMethods(): void {
-    $.fn.extend({
-      popover: function(params: Partial<Popover.Options> | undefined) {
-        // @ts-expect-error because it's JQuery method
-        return this.each(function() {
-          // @ts-expect-error because of the scope
-          new bootstrap.Popover(this, params);
-        });
-      },
-      tooltip: function(params: Partial<Tooltip.Options> | undefined) {
-        // @ts-expect-error because it's JQuery method
-        return this.each(function() {
-          // @ts-expect-error because of the scope
-          new bootstrap.Tooltip(this, params);
-        });
-      }
-    });
   }
 }
 

--- a/tests/unit/index.spec.ts
+++ b/tests/unit/index.spec.ts
@@ -38,28 +38,6 @@ describe('BSCompatibilityLayer', () => {
     expect(mockMutationObserver).toHaveBeenCalledWith(expect.any(Function));
   });
 
-  // BSCompatibilityLayer extends the jQuery object with BS methods.
-  it('should extend the jQuery object with BS methods', () => {
-    // Arrange
-    const mockExtend = jest.fn();
-    const mockJQuery = {
-      fn: {
-        extend: mockExtend
-      }
-    };
-    /**
-     * The global jQuery $ is not added loaded into jest
-     *
-     * @ts-expect-error */
-    global.$ = mockJQuery;
-
-    // Act
-    BSCompatibilityLayer.attachJQueryMethods();
-
-    // Assert
-    expect(mockExtend).toHaveBeenCalledWith(expect.any(Object));
-  });
-
   // BSCompatibilityLayer updates a specific data attribute of an HTML element.
   it('should update a specific data attribute of an HTML element', () => {
     // Arrange

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,7 @@
     "esModuleInterop": true,
     "lib": ["ESNext", "DOM"],
     "skipLibCheck": true,
-    "types": ["@types/jest", "@types/jsdom", "@types/node", "@types/bootstrap", "@types/jquery"],
+    "types": ["@types/jest", "@types/jsdom", "@types/node"],
   },
   "files": ["package.json"],
   "include": ["./**/*.ts"],


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Bootstrap [v5.0.2](https://github.com/twbs/bootstrap/releases/tag/v5.0.2) also implemented JQuery interface for BS methods.
| Type?             | refactor
| BC breaks?        | no
| Deprecations?     | no
| Sponsor company   | @PrestaShopCorp
